### PR TITLE
Fixed time showing wrong in iCal

### DIFF
--- a/src/events/ical.rs
+++ b/src/events/ical.rs
@@ -85,7 +85,7 @@ impl Ical {
                 "End: {}; duration: {}:{:02}",
                 e.format("%H:%M"),
                 duration.num_hours(),
-                duration.num_minutes()
+                duration.num_minutes() % 60
             )
         });
         Event::new(


### PR DESCRIPTION
Time was being shown as hh:mm where hh were the total hours and mm the total minutes, instead of being the remaining minutes.